### PR TITLE
add u16, u32, u256 syntax highlighting 

### DIFF
--- a/syntaxes/move.tmLanguage.json
+++ b/syntaxes/move.tmLanguage.json
@@ -608,7 +608,7 @@
 
         "primitives": {
             "comment": "Primitive types",
-            "match": "\\b(u8|u64|u128|address|bool|signer)\\b",
+            "match": "\\b(u8|u16|u32|u64|u128|u256|address|bool|signer)\\b",
             "name": "support.type.primitives.move"
         },
 
@@ -728,7 +728,7 @@
 
         "spec_types": {
             "comment": "Spec-only types",
-            "match": "\\b(range|num|vector|bool|u8|u64|u128|address)\\b",
+            "match": "\\b(range|num|vector|bool|u8|u16|u32|u64|u128|u256|address)\\b",
             "name": "support.type.vector.move"
         },
 


### PR DESCRIPTION
We've added new integer types in upstream Move: https://github.com/move-language/move/pull/547
For syntax highlighting, we need the support here.