### PR TITLE
fix the mdx grammar injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,6 @@
           ".move"
         ],
         "configuration": "./language-configuration.json"
-      },
-      {
-        "id": "move-markdown-injection"
-      },
-      {
-        "id": "move-mdx-injection"
       }
     ],
     "grammars": [
@@ -43,7 +37,6 @@
         "path": "./syntaxes/move.tmLanguage.json"
       },
       {
-        "language": "move-markdown-injection",
         "scopeName": "markdown.move.codeblock",
         "path": "./syntaxes/move-markdown-injection.json",
         "injectTo": [
@@ -54,7 +47,6 @@
         }
       },
       {
-        "language": "move-mdx-injection",
         "scopeName": "mdx.move.codeblock",
         "path": "./syntaxes/move-mdx-injection.json",
         "injectTo": [

--- a/syntaxes/move-mdx-injection.json
+++ b/syntaxes/move-mdx-injection.json
@@ -1,42 +1,55 @@
 {
     "fileTypes": [],
+    "scopeName": "mdx.move.codeblock",
     "injectionSelector": "L:source.mdx",
     "patterns": [
         {
-            "include": "#LANGUAGE-code-block"
-        }
-    ],
-    "repository": {
-        "LANGUAGE-code-block": {
-            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(LANGUAGE)",
-            "name": "markup.code.other.mdx",
-            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "begin": "(?:^|\\G)[\\t ]*(`{3,})(?:[\\t ]*((?i:(?:.*\\.)?move))(?:[\\t ]+((?:[^\\n\\r`])+))?)(?:[\\t ]*$)",
             "beginCaptures": {
-                "3": {
+                "1": {
                     "name": "string.other.begin.code.fenced.mdx"
                 },
-                "4": {
+                "2": {
                     "name": "entity.name.function.mdx"
                 }
             },
+            "contentName": "meta.embedded.move",
+            "end": "(\\1)(?:[\\t ]*$)",
             "endCaptures": {
-                "3": {
+                "1": {
                     "name": "string.other.end.code.fenced.mdx"
                 }
             },
+            "name": "markup.code.move.mdx",
             "patterns": [
                 {
-                    "begin": "(^|\\G)(\\s*)(.*)",
-                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
-                    "contentName": "meta.embedded.block.LANGUAGE",
-                    "patterns": [
-                        {
-                            "include": "source.LANGUAGE"
-                        }
-                    ]
+                    "include": "source.move"
+                }
+            ]
+        },
+        {
+            "begin": "(?:^|\\G)[\\t ]*(~{3,})(?:[\\t ]*((?i:(?:.*\\.)?move))(?:[\\t ]+((?:[^\\n\\r])+))?)(?:[\\t ]*$)",
+            "beginCaptures": {
+                "1": {
+                    "name": "string.other.begin.code.fenced.mdx"
+                },
+                "2": {
+                    "name": "entity.name.function.mdx"
+                }
+            },
+            "contentName": "meta.embedded.move",
+            "end": "(\\1)(?:[\\t ]*$)",
+            "endCaptures": {
+                "1": {
+                    "name": "string.other.end.code.fenced.mdx"
+                }
+            },
+            "name": "markup.code.move.mdx",
+            "patterns": [
+                {
+                    "include": "source.move"
                 }
             ]
         }
-    },
-    "scopeName": "mdx.LANGUAGE.codeblock"
+    ]
 }


### PR DESCRIPTION
I’m documenting how to add support for custom languages in MDX code blocks in https://github.com/mdx-js/mdx-analyzer/pull/444. I remember someone asking for this a while ago in one of the MDX issues / discussions, but I can’t find it anymore. I think it was you. :)

The MDX syntax has been updated since. This PR updates the syntax here accordingly. I also found [this gist](https://gist.github.com/damirka/28ec6adb09b3047da3ae91eaa92df3dd) which is now outdated.

This also removes the `move-markdown-injection` and `move-mdx-injection` language IDs. No languages need to be registered for grammar injection. These languages do show up in the VSCode language selector, which is undesirable.