### PR TITLE
fix highlighting of functions in `spec module` (like in vector.move)

### DIFF
--- a/syntaxes/move.tmLanguage.json
+++ b/syntaxes/move.tmLanguage.json
@@ -1065,7 +1065,8 @@
                         { "include": "#fun_call" },
                         { "include": "#literals" },
                         { "include": "#types" },
-                        { "include": "#let" }
+                        { "include": "#let" },
+                        { "include": "#fun" }
                     ]
                 }
             ]


### PR DESCRIPTION
Hey!

While learning the Move language, I noticed that in [`vector.move`](https://github.com/move-language/move/blob/main/language/move-stdlib/sources/vector.move) the functions in `spec module { ... }` are not fully highlighted. This PR fixes that issue

Before:
<img width="247" src="https://github.com/user-attachments/assets/73928c7f-3012-4f2e-a075-08a0efda7966">

After:
<img width="249" src="https://github.com/user-attachments/assets/3b569497-79f3-40a3-8123-2b3d94fa3ec6">

