### PR TITLE
better highlighting of ALL_CAPS_CONSTANTS

### DIFF
--- a/syntaxes/move.tmLanguage.json
+++ b/syntaxes/move.tmLanguage.json
@@ -932,7 +932,7 @@
 
                 {
                     "comment": "ALL_CONST_CAPS",
-                    "name": "constant.other.move",
+                    "name": "variable.other.constant.move",
                     "match": "\\b([A-Z][A-Z_]+)\\b"
                 },
 


### PR DESCRIPTION
While the current modifier works in some themes, with the new modifier the highlighting works in more themes and is more consistent with other languages like Rust.

Before:
<img width="413" src="https://github.com/user-attachments/assets/23b0b942-3a1a-401d-adc1-d4145cdac7ba">

After:
<img width="413" src="https://github.com/user-attachments/assets/c3267211-e256-454d-8428-1ab7b6c2d6af">
